### PR TITLE
make it compile (fix size of stat.st_nlink)

### DIFF
--- a/pypycore.py
+++ b/pypycore.py
@@ -9,6 +9,11 @@ __all__ = ['get_version',
            'time',
            'loop']
 
+def st_nlink_type():
+    if sys.platform == "darwin":
+        return "short"
+    return "long long"
+
 
 from cffi import FFI
 ffi = FFI()
@@ -98,7 +103,7 @@ struct ev_child {
 };
 
 struct stat {
-    short st_nlink;
+    """ + st_nlink_type() + """ st_nlink;
     ...;
 };
 

--- a/pypycore.py
+++ b/pypycore.py
@@ -98,7 +98,7 @@ struct ev_child {
 };
 
 struct stat {
-    long long st_nlink;
+    short st_nlink;
     ...;
 };
 


### PR DESCRIPTION
I don't really understand what's going on, but on my OS X machine, trying to install this package would result in an error message saying:

```
VerificationError: function ev_stat_init: field 'stat.st_nlink' is declared as 8 bytes, but is really 2 bytes
```

So I just fixed this field to make it 2 bytes instead of 8. After making the change, everything went smoothly!
